### PR TITLE
Remove unsafeFlags to be compatible with SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
                     .define("LIBPLZMA_VERSION_BUILD", to: "368")
                 ],
                 cxxSettings: [
-                    .define("LIBPLZMA_VERSION_BUILD", to: "368"),
-                    .unsafeFlags(["-fno-rtti"])
+                    .define("LIBPLZMA_VERSION_BUILD", to: "368")
         ]),
         .target(name: "PLzmaSDK",
                 dependencies: [


### PR DESCRIPTION
I don't know why this flag has been added to the latest release but Xcode won't let us compile our application due to unsafe flags in this package. Removing it fixed the issue 🤷‍♂️